### PR TITLE
Fix --monitor-disk cross-platform

### DIFF
--- a/docs/issue-21-plan.md
+++ b/docs/issue-21-plan.md
@@ -1,0 +1,56 @@
+# Plan: tools/build_matrix.py `--monitor-disk` をクロスプラットフォーム対応 (issue #21)
+
+## 概要
+
+`tools/build_matrix.py` の `--monitor-disk` が内部で呼ぶ `get_disk_free_gb()` が
+`shutil.disk_usage("C:\\")` に固定されており、Linux/macOS で例外になってクラッシュする。
+
+目的: `--monitor-disk` が少なくとも Linux + Windows で動作すること。
+
+## 変更対象
+
+- [../tools/build_matrix.py](../tools/build_matrix.py)
+
+## 方針
+
+- `shutil.disk_usage()` に渡すパスを OS で切り替える
+  - Windows: `SystemDrive` を優先し、未設定時は `C:\\`
+  - 非 Windows: `/`
+- 可能なら「どのパーティションを監視しているか」が分かるように、例外時のフォールバックも用意する
+  - 最小構成: 上記パスで十分
+  - 安全策: 失敗したら `Path.cwd()`（ワークスペースがあるパーティション）を試す
+
+## Steps
+
+1. **`get_disk_free_gb()` を OS 依存しない実装へ変更**
+
+   対象: [tools/build_matrix.py](../tools/build_matrix.py#L45)
+
+   - Before: `shutil.disk_usage("C:\\")`
+   - After:
+     - `platform.system()` もしくは `os.name` で Windows 判定
+     - Windows の場合は `os.environ.get("SystemDrive", "C:") + "\\"`
+     - 非 Windows は `/`
+     - 例外時は `Path.cwd()` などにフォールバック（必要なら）
+
+2. **（任意だが推奨）リグレッションテストを追加**
+
+   - 新規: `tests/test_build_matrix_monitor_disk.py`
+   - ねらい: Linux 環境で `get_disk_free_gb()` が例外を投げず float を返すこと
+   - 実装案:
+     - Windows 判定を `platform.system()` に寄せておく（`monkeypatch` で差し替えやすい）
+     - もしくは判定/パス決定を `_disk_usage_path()` のような小関数に分離して単体テストする
+
+## Verification
+
+- Linux でクラッシュしないこと:
+  - `uv run python tools/build_matrix.py --all --monitor-disk --dry-run`
+- 既存チェック:
+  - `uv run pyright`
+  - `uv run flake8`
+  - `uv run pytest`
+
+## Decisions
+
+- 非 Windows の監視対象は `/` をデフォルトにする（issue 提案に合わせた最小修正）
+- Windows は `SystemDrive` を優先し、フォールバックは `C:\\`

--- a/tests/test_build_matrix_monitor_disk.py
+++ b/tests/test_build_matrix_monitor_disk.py
@@ -21,6 +21,13 @@ def test_disk_usage_path_windows_uses_system_drive(monkeypatch):
     assert module._disk_usage_path() == "D:\\"
 
 
+def test_disk_usage_path_windows_normalizes_trailing_slash(monkeypatch):
+    module = _load_build_matrix_module()
+    monkeypatch.setattr(module.platform, "system", lambda: "Windows")
+    monkeypatch.setenv("SystemDrive", "D:\\")
+    assert module._disk_usage_path() == "D:\\"
+
+
 def test_disk_usage_path_non_windows_is_root(monkeypatch):
     module = _load_build_matrix_module()
     monkeypatch.setattr(module.platform, "system", lambda: "Linux")

--- a/tests/test_build_matrix_monitor_disk.py
+++ b/tests/test_build_matrix_monitor_disk.py
@@ -1,0 +1,43 @@
+import importlib.util
+from collections import namedtuple
+from pathlib import Path
+
+
+def _load_build_matrix_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "tools" / "build_matrix.py"
+    spec = importlib.util.spec_from_file_location("build_matrix", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_disk_usage_path_windows_uses_system_drive(monkeypatch):
+    module = _load_build_matrix_module()
+    monkeypatch.setattr(module.platform, "system", lambda: "Windows")
+    monkeypatch.setenv("SystemDrive", "D:")
+    assert module._disk_usage_path() == "D:\\"
+
+
+def test_disk_usage_path_non_windows_is_root(monkeypatch):
+    module = _load_build_matrix_module()
+    monkeypatch.setattr(module.platform, "system", lambda: "Linux")
+    assert module._disk_usage_path() == "/"
+
+
+def test_get_disk_free_gb_uses_selected_path(monkeypatch):
+    module = _load_build_matrix_module()
+    monkeypatch.setattr(module.platform, "system", lambda: "Linux")
+
+    Usage = namedtuple("Usage", ["total", "used", "free"])
+    calls = []
+
+    def fake_disk_usage(path: str):
+        calls.append(path)
+        return Usage(total=0, used=0, free=10 * 1024**3)
+
+    monkeypatch.setattr(module.shutil, "disk_usage", fake_disk_usage)
+    assert module.get_disk_free_gb() == 10.0
+    assert calls == ["/"]

--- a/tools/build_matrix.py
+++ b/tools/build_matrix.py
@@ -61,7 +61,9 @@ def _is_windows() -> bool:
 
 def _disk_usage_path() -> str:
     if _is_windows():
-        system_drive = os.environ.get("SystemDrive") or "C:"
+        system_drive = (os.environ.get("SystemDrive") or "C:").rstrip("\\/")
+        if len(system_drive) == 1 and system_drive.isalpha():
+            system_drive = f"{system_drive}:"
         # shutil.disk_usage はドライブ直下のパスを期待する（例: "C:\\"）
         return f"{system_drive}\\"
     return "/"

--- a/tools/build_matrix.py
+++ b/tools/build_matrix.py
@@ -23,6 +23,8 @@ build-matrix.yaml の設定を読み込んで、複数のDocker イメージを�
 
 import shutil
 import subprocess
+import os
+import platform
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -43,9 +45,26 @@ def load_matrix(file_path: Path) -> dict[str, Any]:
 
 
 def get_disk_free_gb() -> float:
-    """Cドライブの空き容量をGBで取得"""
-    stat = shutil.disk_usage("C:\\")
+    """ディスク空き容量をGBで取得（OSに応じたルートを監視）"""
+    target_path = _disk_usage_path()
+    try:
+        stat = shutil.disk_usage(target_path)
+    except (FileNotFoundError, OSError, ValueError):
+        # ルートが解決できない環境（chroot等）ではカレントディレクトリをフォールバックにする
+        stat = shutil.disk_usage(str(Path.cwd()))
     return stat.free / (1024**3)
+
+
+def _is_windows() -> bool:
+    return platform.system().lower().startswith("win")
+
+
+def _disk_usage_path() -> str:
+    if _is_windows():
+        system_drive = os.environ.get("SystemDrive") or "C:"
+        # shutil.disk_usage はドライブ直下のパスを期待する（例: "C:\\"）
+        return f"{system_drive}\\"
+    return "/"
 
 
 def push_to_registry(image_tag: str, registry_url: str = "localhost:5001") -> bool:


### PR DESCRIPTION
Fixes #21

- Make `tools/build_matrix.py --monitor-disk` work cross-platform by selecting a valid root path (`/` on non-Windows, `%SystemDrive%` on Windows)
- Add regression tests for disk path selection + `get_disk_free_gb()`

Verified:
- uv run pyright
- uv run flake8
- uv run pytest